### PR TITLE
Fix post pagination when basePath is empty

### DIFF
--- a/packages/gatsby-theme-post/gatsby-node.js
+++ b/packages/gatsby-theme-post/gatsby-node.js
@@ -165,12 +165,13 @@ exports.createPages = async ({ actions, graphql, reporter }, themeOptions) => {
 
   if (posts.length) {
     const publishedPosts = posts.filter(({ published }) => published)
+    const paginatedBasePath = basePath === `` ? `/` : `${basePath}/`
     paginate({
       createPage,
       items: publishedPosts,
       itemsPerPage: postsPerPage,
       pathPrefix: ({ pageNumber }) =>
-        pageNumber === 0 ? basePath : `${basePath}/page`,
+        pageNumber === 0 ? paginatedBasePath : `${paginatedBasePath}page`,
       component: require.resolve(`./src/posts-template.js`),
       context: {
         total: publishedPosts.length,


### PR DESCRIPTION
When trying to place posts at the root level via an empty `basePath`, e.g.:

    {
      resolve: `@reflexjs/gatsby-theme-post`,
      options: {
        basePath: ``,
      },
    },

the pagination code generated an error while generating page 1 due to an empty page path:
```error The plugin "@reflexjs/gatsby-theme-post" must set the page path when creating a page.```

(Note that trying to achieve the same post placement by setting ``basePath: `/` `` leads to different problems, such as paths of the form `//page/2`.)
